### PR TITLE
Add support for multiple features in the middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ You can change the status code using the `middleware.code` configuration option.
 
 If you would prefer to redirect instead of aborting, set `middleware.behaviour` to `MiddlewareBehaviour::Redirect` and `middleware.redirect` to your preferred redirect location.
 
+#### Multiple features
+
+If you wish, you may protect your routes behind multiple feature flags. You can do this by comma-separating the flags passed when defining the middleware on your route definition:
+
+```php
+Route::get('/feature', fn () => ...)->middleware('feature:verified,two-factor');
+```
+
 ## Testing
 
 ```bash

--- a/src/Middleware/HasFeature.php
+++ b/src/Middleware/HasFeature.php
@@ -15,16 +15,18 @@ class HasFeature
     ) {
     }
 
-    public function handle(Request $request, Closure $next, string $name)
+    public function handle(Request $request, Closure $next, string ...$features)
     {
-        if (Features::enabled($name)) {
-            return $next($request);
+        foreach ($features as $feature) {
+            if (! Features::enabled($feature)) {
+                if ($this->features->getMiddlewareBehaviour() === MiddlewareBehaviour::Abort) {
+                    abort($this->features->getMiddlewareAbortCode());
+                }
+
+                return redirect()->to($this->features->getMiddlewareRedirect());
+            }
         }
 
-        if ($this->features->getMiddlewareBehaviour() === MiddlewareBehaviour::Abort) {
-            abort($this->features->getMiddlewareAbortCode());
-        }
-
-        return redirect()->to($this->features->getMiddlewareRedirect());
+        return $next($request);
     }
 }

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -10,6 +10,9 @@ use RyanChandler\LaravelFeatureFlags\Middleware\HasFeature;
 beforeEach(function () {
     Route::get('/features', function () {
     })->middleware(HasFeature::class . ':foo');
+
+    Route::get('/multi-features', function () {
+    })->middleware(HasFeature::class . ':foo,bar');
 });
 
 test('the middleware correctly aborts', function () {
@@ -52,5 +55,59 @@ test('the middleware correctly redirects', function () {
     Features::disable('foo');
 
     get('/features')
+        ->assertRedirect('/bar');
+});
+
+test('the middleware allows multiple features', function () {
+    Features::enable('foo');
+    Features::enable('bar');
+
+    get('/multi-features')
+        ->assertOk();
+});
+
+test('the middleware correctly aborts for multiple features if one is not enabled', function () {
+    Features::enable('foo');
+    Features::enable('bar');
+
+    get('/multi-features')
+        ->assertOk();
+
+    Features::disable('bar');
+
+    get('/multi-features')
+        ->assertForbidden();
+});
+
+test('the middleware correctly aborts with custom code for multiple features if one is not enabled', function () {
+    config(['feature-flags.middleware.code' => 404]);
+
+    Features::enable('foo');
+    Features::enable('bar');
+
+    get('/multi-features')
+        ->assertOk();
+
+    Features::disable('bar');
+
+    get('/multi-features')
+        ->assertNotFound();
+});
+
+test('the middleware correctly redirects for multiple features if one is not enabled', function () {
+    config([
+        'feature-flags.middleware.behaviour' => MiddlewareBehaviour::Redirect,
+        'feature-flags.middleware.redirect' => '/bar',
+    ]);
+
+    Features::enable('foo');
+    Features::enable('bar');
+
+    get('/multi-features')
+        ->assertOk();
+
+    Features::disable('foo');
+
+    get('/multi-features')
         ->assertRedirect('/bar');
 });


### PR DESCRIPTION
This PR add's multi-feature support to `HasFeature` middleware, using Laravel's comma-separated argument syntax when defining middleware on the route:

```php
use App\Http\Controllers\FooController;
use RyanChandler\LaravelFeatureFlags\Middleware\HasFeature;

Route::get('foo', [FooController::class, 'index')->middleware(HasFeature::class, . ':foo,bar');
```